### PR TITLE
Fix empty selections in file chooser

### DIFF
--- a/context_video_cutter/utils.py
+++ b/context_video_cutter/utils.py
@@ -60,6 +60,8 @@ def select_file(file_type, file_label=None, additional_labels=None):
         files_path = filedialog.askopenfilenames(
             filetypes=[("All Files", "*.*")], initialdir=source_dir
         )
+        if not files_path:
+            return files_path
         config_manager.set_source_file_path(files_path[0])
         if file_label:
             file_label.configure(foreground="green", text=Path(files_path[0]).name)
@@ -69,11 +71,15 @@ def select_file(file_type, file_label=None, additional_labels=None):
         files_path = filedialog.askopenfilenames(
             filetypes=[("SRT Files", "*.srt")], initialdir=output_dir
         )
+        if not files_path:
+            return files_path
         config_manager.set_subs_file_path(files_path[0])
         if file_label:
             file_label.configure(foreground="green", text=Path(files_path[0]).name)
     if file_type == "clips_json":
         files_path = filedialog.askopenfilenames(filetypes=[("JSON Files", "*.json")])
+        if not files_path:
+            return files_path
         config_manager.set_clips_json_path(files_path[0])
         with open(files_path[0], "r", encoding="utf-8") as f:
             clip_times = json.load(f)


### PR DESCRIPTION
## Summary
- avoid index errors in `select_file` by checking for a chosen file

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68616d79fad8832fa09060f5599c24c4