### PR TITLE
Create config.toml if missing

### DIFF
--- a/context_video_cutter/config_manager.py
+++ b/context_video_cutter/config_manager.py
@@ -1,4 +1,5 @@
 from pathlib import Path
+import shutil
 import toml
 
 BASE_DIR = Path(__file__).resolve().parent.parent
@@ -6,9 +7,9 @@ config_path = BASE_DIR / "config.toml"
 template_path = BASE_DIR / "config.example.toml"
 if not config_path.exists():
     print("⚠ config.toml not found — creating from template.")
-    _raw = toml.load(template_path)
-else:
-    _raw = toml.load(config_path)
+    shutil.copy(template_path, config_path)
+
+_raw = toml.load(config_path)
 
 output_dir = (BASE_DIR / _raw["paths"]["output_dir_base"]).as_posix()
 language = _raw["default"]["language"]

--- a/context_video_cutter/gui.py
+++ b/context_video_cutter/gui.py
@@ -1,6 +1,7 @@
 import threading
 import tkinter as tk
 from pathlib import Path
+import shutil
 from tkinter import ttk
 
 import context_video_cutter.subtitle_processing as subtitle_processing
@@ -15,9 +16,9 @@ config_path = BASE_DIR / "config.toml"
 template_path = BASE_DIR / "config.example.toml"
 if not config_path.exists():
     print("⚠ config.toml not found — creating from template.")
-    config = toml.load(template_path)
-else:
-    config = toml.load(config_path)
+    shutil.copy(template_path, config_path)
+
+config = toml.load(config_path)
 BASE_OUTPUT_DIR = (BASE_DIR / config["paths"]["output_dir_base"]).as_posix()
 SOURCES_DIR = (BASE_DIR / config["paths"]["sources_dir"]).as_posix()
 

--- a/context_video_cutter/subtitle_processing.py
+++ b/context_video_cutter/subtitle_processing.py
@@ -2,6 +2,7 @@ import threading
 import os
 from datetime import datetime, timedelta
 from pathlib import Path
+import shutil
 from tkinter import messagebox
 
 import pysrt
@@ -19,9 +20,9 @@ config_path = BASE_DIR / "config.toml"
 template_path = BASE_DIR / "config.example.toml"
 if not config_path.exists():
     print("⚠ config.toml not found — creating from template.")
-    config = toml.load(template_path)
-else:
-    config = toml.load(config_path)
+    shutil.copy(template_path, config_path)
+
+config = toml.load(config_path)
 
 
 def transcribe_video(labels, log_box, tk):

--- a/context_video_cutter/uploader.py
+++ b/context_video_cutter/uploader.py
@@ -2,6 +2,7 @@ import json
 import sys
 from datetime import datetime, timedelta
 from pathlib import Path
+import shutil
 from tkinter import messagebox
 from tiktokautouploader import upload_tiktok
 
@@ -15,9 +16,9 @@ config_path = BASE_DIR / "config.toml"
 template_path = BASE_DIR / "config.example.toml"
 if not config_path.exists():
     print("⚠ config.toml not found — creating from template.")
-    config = toml.load(template_path)
-else:
-    config = toml.load(config_path)
+    shutil.copy(template_path, config_path)
+
+config = toml.load(config_path)
 
 #Supported only ENG accounts!
 def upload_tik_tok_videos(labels, log_box, tk):

--- a/context_video_cutter/utils.py
+++ b/context_video_cutter/utils.py
@@ -6,6 +6,7 @@ from datetime import timedelta
 
 import toml
 from pathlib import Path
+import shutil
 from tkinter import filedialog, messagebox
 import yt_dlp
 from faster_whisper import WhisperModel
@@ -19,9 +20,9 @@ config_path = BASE_DIR / "config.toml"
 template_path = BASE_DIR / "config.example.toml"
 if not config_path.exists():
     print("⚠ config.toml not found — creating from template.")
-    config = toml.load(template_path)
-else:
-    config = toml.load(config_path)
+    shutil.copy(template_path, config_path)
+
+config = toml.load(config_path)
 
 
 class YTDLPLogger:

--- a/context_video_cutter/video_processing.py
+++ b/context_video_cutter/video_processing.py
@@ -3,6 +3,7 @@ import os
 import subprocess
 from datetime import datetime
 from pathlib import Path
+import shutil
 from tkinter import messagebox
 
 import pysrt
@@ -18,9 +19,9 @@ config_path = BASE_DIR / "config.toml"
 template_path = BASE_DIR / "config.example.toml"
 if not config_path.exists():
     print("⚠ config.toml not found — creating from template.")
-    config = toml.load(template_path)
-else:
-    config = toml.load(config_path)
+    shutil.copy(template_path, config_path)
+
+config = toml.load(config_path)
 
 
 def cut_video(labels, log_box, tk):


### PR DESCRIPTION
## Summary
- create `config.toml` from `config.example.toml` if it doesn't exist
- apply this creation step in all modules that previously only loaded the template

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68616d914734832f8841ffe53824731d